### PR TITLE
issue #3 "Use of uninitialized value $sMethodName" problem

### DIFF
--- a/lib/Doxygen/Filter/Perl.pm
+++ b/lib/Doxygen/Filter/Perl.pm
@@ -673,6 +673,8 @@ sub _ProcessPerlMethod
         push (@{$self->{'_hData'}->{'class'}->{$sClassName}->{'subroutineorder'}}, $sName); 
         $self->{'_sCurrentMethodName'} = $sName; 
     }
+    if (!defined($self->{'_sCurrentMethodName'})) {$self->{'_sCurrentMethodName'}='';}
+
     my $sMethodName = $self->{'_sCurrentMethodName'};
     
     # Lets find out if this is a public or private method/function based on a naming standard


### PR DESCRIPTION
Fixing: Use of uninitialized value $sMethodName in pattern match (m//) at /home/User/perl5/lib/perl5/Doxygen/Filter/Perl.pm line 679. (and further lines)