### PR TITLE
Uninitialized value $sOptions

### DIFF
--- a/lib/Doxygen/Filter/Perl.pm
+++ b/lib/Doxygen/Filter/Perl.pm
@@ -822,6 +822,13 @@ sub _ProcessDoxygenCommentBlock
     $sCommandLine =~ /^\s*#\*\*\s+\@([\w:]+)\s+(.*)/;
     my $sCommand = lc($1);
     my $sOptions = $2; 
+    if (!defined($sOptions))
+    {
+      # Lets check special case with a '.' or ',' e.g @winchhooks.
+      $sCommandLine =~ /^\s*#\*\*\s+\@([\w:]+)([\.,].*)/;
+      $sCommand = lc($1);
+      $sOptions = "$2";
+    }
     $logger->debug("Command: $sCommand");
     $logger->debug("Options: $sOptions");
 

--- a/lib/Doxygen/Filter/Perl.pm
+++ b/lib/Doxygen/Filter/Perl.pm
@@ -827,7 +827,11 @@ sub _ProcessDoxygenCommentBlock
       # Lets check special case with a '.' or ',' e.g @winchhooks.
       $sCommandLine =~ /^\s*#\*\*\s+\@([\w:]+)([\.,].*)/;
       $sCommand = lc($1);
-      $sOptions = "$2";
+      $sOptions = "";
+      if (defined($2))
+      {
+        $sOptions = "$2";
+      }
     }
     $logger->debug("Command: $sCommand");
     $logger->debug("Options: $sOptions");


### PR DESCRIPTION
In case we have a command line, in the perl script, like:
```
@winchook.
```
we get a message like (line number might be off due to other patches):
```
Use of uninitialized value $sOptions in concatenation (.) or string at /usr/lib/perl5/site_perl/5.18.2/Doxygen/Filter/Perl.pm line 835.
```

In case of a not set `$sOptions` we now see whether a '.' or ',' is present.