### PR TITLE
Correct file name in case of space in the name

### DIFF
--- a/lib/Doxygen/Filter/Perl.pm
+++ b/lib/Doxygen/Filter/Perl.pm
@@ -521,7 +521,7 @@ sub _PrintFilenameBlock
     
     if (defined $self->{'_hData'}->{'filename'}->{'fullpath'})
     {
-        print "/** \@file $self->{'_hData'}->{'filename'}->{'fullpath'}\n";
+        print "/** \@file \"$self->{'_hData'}->{'filename'}->{'fullpath'}\"\n";
         if (defined $self->{'_hData'}->{'filename'}->{'details'}) { print "$self->{'_hData'}->{'filename'}->{'details'}\n"; }
         if (defined $self->{'_hData'}->{'filename'}->{'version'}) { print "\@version $self->{'_hData'}->{'filename'}->{'version'}\n"; }
         print "*/\n";        


### PR DESCRIPTION
Some files have a space in the name ( :-( ) and therefore the filename for the file command should be between quotes.