### PR TITLE
Fix for some uninitialized variables

### DIFF
--- a/lib/Doxygen/Filter/Perl.pm
+++ b/lib/Doxygen/Filter/Perl.pm
@@ -286,8 +286,12 @@ sub ProcessFile
                     {
                         if ($sIncludeModule eq "base")
                         {
-                            my @isa = eval($expr);
-                            push(@{$self->GetCurrentClass()->{inherits}}, _FilterOutSystemPackages(@isa)) unless ($@);
+                            if (substr($expr,0,8) =~ /\"require/) { }
+                            else
+                            {
+                                my @isa = eval($expr);
+                                push(@{$self->GetCurrentClass()->{inherits}}, _FilterOutSystemPackages(@isa)) unless ($@);
+                            }
                         }
                         else
                         {
@@ -444,7 +448,12 @@ sub PrintAll
 # ----------------------------------------
 # Private Methods
 # ----------------------------------------
-sub _FilterOutSystemPackages { return grep({ !exists $SYSTEM_PACKAGES{$_} } @_); }
+sub _FilterOutSystemPackages
+{
+   if (!defined($_)) { return @_};
+   return grep({ !exists $SYSTEM_PACKAGES{$_} } @_);
+}
+
 
 sub _SwitchClass 
 { 


### PR DESCRIPTION
The following constructs:
`our @ISA = $Net::FTP::IOCLASS;`
and
`    use base "require  $DADA::Config::CAPTCHA_TYPE";`
lead to messages like:
```
Use of uninitialized value $_ in exists at /usr/lib/perl5/site_perl/5.18.2/Doxygen/Filter/Perl.pm line 447.
Use of uninitialized value $DADA::Config::CAPTCHA_TYPE in concatenation (.) or string at (eval 30) line 1.
```