### PR TITLE
Uninitialized variable

### DIFF
--- a/lib/Doxygen/Filter/Perl.pm
+++ b/lib/Doxygen/Filter/Perl.pm
@@ -584,7 +584,11 @@ sub _PrintClassBlock
         my $count = 0;
         foreach my $inherit (@{$classDef->{inherits}})
         {
-            print(($count++ == 0 ? ": " : ", ")." public ::".$inherit);
+            if (defined($inherit))
+            {
+                print(($count++ == 0 ? ": " : ", ")." public ::".$inherit);
+            }
+
         }
     }
     print "\n{\n";


### PR DESCRIPTION
Another uninitialized variable:
```
Use of uninitialized value $inherit in concatenation (.) or string at /usr/lib/perl5/site_perl/5.18.2/Doxygen/Filter/Perl.pm line 595.
```