### PR TITLE
Correcting multiple use of doxygen section labels

### DIFF
--- a/lib/Doxygen/Filter/Perl.pm
+++ b/lib/Doxygen/Filter/Perl.pm
@@ -790,6 +790,7 @@ sub _ProcessPodCommentBlock
 
     my $parser = new Pod::POM();
     my $pom = $parser->parse_text($sPodRawText);
+    Doxygen::Filter::Perl::POD->setAsLabel($self->{'_hData'}->{'filename'}->{'fullpath'});
     my $sPodParsedText = Doxygen::Filter::Perl::POD->print($pom);
 
     $self->{'_hData'}->{'class'}->{$sClassName}->{'comments'} .= $sPodParsedText;

--- a/lib/Doxygen/Filter/Perl/POD.pm
+++ b/lib/Doxygen/Filter/Perl/POD.pm
@@ -30,7 +30,43 @@ use Log::Log4perl;
 
 our $VERSION     = '1.72';
 $VERSION = eval $VERSION;
+our $labelCnt = 0;  # label counter to see to it that when e.g. twice a =head1 NAME in a file it is still an unique label
+our $sectionLabel = 'x';
 
+sub setAsLabel
+{
+    # based on e.g. a file name try to create a doxygen label prefix
+    my $self = shift;
+    $sectionLabel = shift;
+    $sectionLabel =~ s/_/__/g;
+    $sectionLabel =~ s/:/_1/g;
+    $sectionLabel =~ s/\//_2/g;
+    $sectionLabel =~ s/</_3/g;
+    $sectionLabel =~ s/>/_4/g;
+    $sectionLabel =~ s/\*/_5/g;
+    $sectionLabel =~ s/&/_6/g;
+    $sectionLabel =~ s/\|/_7/g;
+    $sectionLabel =~ s/\./_8/g;
+    $sectionLabel =~ s/!/_9/g;
+    $sectionLabel =~ s/,/_00/g;
+    $sectionLabel =~ s/ /_01/g;
+    $sectionLabel =~ s/{/_02/g;
+    $sectionLabel =~ s/}/_03/g;
+    $sectionLabel =~ s/\?/_04/g;
+    $sectionLabel =~ s/\^/_05/g;
+    $sectionLabel =~ s/%/_06/g;
+    $sectionLabel =~ s/\(/_07/g;
+    $sectionLabel =~ s/\)/_08/g;
+    $sectionLabel =~ s/\+/_09/g;
+    $sectionLabel =~ s/=/_0A/g;
+    $sectionLabel =~ s/\$/_0B/g;
+    $sectionLabel =~ s/\\/_0C/g;
+    $sectionLabel =~ s/@/_0D/g;
+    $sectionLabel =~ s/-/_0E/g;
+    $sectionLabel =~ s/[^a-z0-9A-Z]/_/g;
+
+    $sectionLabel = "x$sectionLabel"; # label should not start with a underscore
+}
 
 sub view_pod 
 {
@@ -44,7 +80,8 @@ sub view_head1
     my $title = $head1->title->present($self);
     my $name = $title;
     $name =~ s/\s/_/g;
-    return "\n\@section $name $title\n" . $head1->content->present($self);
+    $labelCnt += 1;
+    return "\n\@section $sectionLabel$name$labelCnt $title\n" . $head1->content->present($self);
 }
 
 sub view_head2 
@@ -53,7 +90,28 @@ sub view_head2
     my $title = $head2->title->present($self);
     my $name = $title;
     $name =~ s/\s/_/g;    
-    return "\n\@subsection $name $title\n" . $head2->content->present($self);
+    $labelCnt += 1;
+    return "\n\@subsection $sectionLabel$name$labelCnt $title\n" . $head2->content->present($self);
+}
+
+sub view_head3
+{
+    my ($self, $head3) = @_;
+    my $title = $head3->title->present($self);
+    my $name = $title;
+    $name =~ s/\s/_/g;    
+    $labelCnt += 1;
+    return "\n\@subsubsection $sectionLabel$name$labelCnt $title\n" . $head3->content->present($self);
+}
+
+sub view_head4 
+{
+    my ($self, $head4) = @_;
+    my $title = $head4->title->present($self);
+    my $name = $title;
+    $name =~ s/\s/_/g;    
+    $labelCnt += 1;
+    return "\n\@paragraph $sectionLabel$name$labelCnt $title\n" . $head4->content->present($self);
 }
 
 sub view_seq_code 

--- a/lib/Doxygen/Filter/Perl/POD.pm
+++ b/lib/Doxygen/Filter/Perl/POD.pm
@@ -33,39 +33,46 @@ $VERSION = eval $VERSION;
 our $labelCnt = 0;  # label counter to see to it that when e.g. twice a =head1 NAME in a file it is still an unique label
 our $sectionLabel = 'x';
 
+sub convertText
+{
+    # based on e.g. a file name try to create a doxygen label prefix
+    my $label = shift;
+    $label =~ s/_/__/g;
+    $label =~ s/:/_1/g;
+    $label =~ s/\//_2/g;
+    $label =~ s/</_3/g;
+    $label =~ s/>/_4/g;
+    $label =~ s/\*/_5/g;
+    $label =~ s/&/_6/g;
+    $label =~ s/\|/_7/g;
+    $label =~ s/\./_8/g;
+    $label =~ s/!/_9/g;
+    $label =~ s/,/_00/g;
+    $label =~ s/ /_01/g;
+    $label =~ s/{/_02/g;
+    $label =~ s/}/_03/g;
+    $label =~ s/\?/_04/g;
+    $label =~ s/\^/_05/g;
+    $label =~ s/%/_06/g;
+    $label =~ s/\(/_07/g;
+    $label =~ s/\)/_08/g;
+    $label =~ s/\+/_09/g;
+    $label =~ s/=/_0A/g;
+    $label =~ s/\$/_0B/g;
+    $label =~ s/\\/_0C/g;
+    $label =~ s/@/_0D/g;
+    $label =~ s/-/_0E/g;
+    $label =~ s/[^a-z0-9A-Z]/_/g;
+    print("New $label\n");
+
+    $label = "x$label"; # label should not start with a underscore
+}
 sub setAsLabel
 {
     # based on e.g. a file name try to create a doxygen label prefix
     my $self = shift;
-    $sectionLabel = shift;
-    $sectionLabel =~ s/_/__/g;
-    $sectionLabel =~ s/:/_1/g;
-    $sectionLabel =~ s/\//_2/g;
-    $sectionLabel =~ s/</_3/g;
-    $sectionLabel =~ s/>/_4/g;
-    $sectionLabel =~ s/\*/_5/g;
-    $sectionLabel =~ s/&/_6/g;
-    $sectionLabel =~ s/\|/_7/g;
-    $sectionLabel =~ s/\./_8/g;
-    $sectionLabel =~ s/!/_9/g;
-    $sectionLabel =~ s/,/_00/g;
-    $sectionLabel =~ s/ /_01/g;
-    $sectionLabel =~ s/{/_02/g;
-    $sectionLabel =~ s/}/_03/g;
-    $sectionLabel =~ s/\?/_04/g;
-    $sectionLabel =~ s/\^/_05/g;
-    $sectionLabel =~ s/%/_06/g;
-    $sectionLabel =~ s/\(/_07/g;
-    $sectionLabel =~ s/\)/_08/g;
-    $sectionLabel =~ s/\+/_09/g;
-    $sectionLabel =~ s/=/_0A/g;
-    $sectionLabel =~ s/\$/_0B/g;
-    $sectionLabel =~ s/\\/_0C/g;
-    $sectionLabel =~ s/@/_0D/g;
-    $sectionLabel =~ s/-/_0E/g;
-    $sectionLabel =~ s/[^a-z0-9A-Z]/_/g;
-
-    $sectionLabel = "x$sectionLabel"; # label should not start with a underscore
+    my $tmpLabel = shift;
+    $sectionLabel = convertText($tmpLabel);
 }
 
 sub view_pod 
@@ -78,8 +85,7 @@ sub view_head1
 {
     my ($self, $head1) = @_;
     my $title = $head1->title->present($self);
-    my $name = $title;
-    $name =~ s/\s/_/g;
+    my $name = convertText($title);
     $labelCnt += 1;
     return "\n\@section $sectionLabel$name$labelCnt $title\n" . $head1->content->present($self);
 }
@@ -88,8 +94,7 @@ sub view_head2
 {
     my ($self, $head2) = @_;
     my $title = $head2->title->present($self);
-    my $name = $title;
-    $name =~ s/\s/_/g;    
+    my $name = convertText($title);
     $labelCnt += 1;
     return "\n\@subsection $sectionLabel$name$labelCnt $title\n" . $head2->content->present($self);
 }
@@ -98,8 +103,7 @@ sub view_head3
 {
     my ($self, $head3) = @_;
     my $title = $head3->title->present($self);
-    my $name = $title;
-    $name =~ s/\s/_/g;    
+    my $name = convertText($title);
     $labelCnt += 1;
     return "\n\@subsubsection $sectionLabel$name$labelCnt $title\n" . $head3->content->present($self);
 }
@@ -108,8 +112,7 @@ sub view_head4
 {
     my ($self, $head4) = @_;
     my $title = $head4->title->present($self);
-    my $name = $title;
-    $name =~ s/\s/_/g;    
+    my $name = convertText($title);
     $labelCnt += 1;
     return "\n\@paragraph $sectionLabel$name$labelCnt $title\n" . $head4->content->present($self);
 }


### PR DESCRIPTION
When having a project with multiple file often messages like:
```
.../RRDs.pm:6: warning: multiple use of section label 'NAME' while adding section, (first occurrence:.../RRDp.pm, line 10)
```
appear. This is due to the fact that that both files have a line:
```
=head1 NAME
```

To overcome this see to it that the create label is unique. This is done based on the fullpath name of the file and a counter.
- Perl.pm
  - transfer the fullpath name to the right (global) place
- Perl.pm
  - adjust file name so we have no "strange" characters in the label
  - adjust the writing of the head1 and head2
  - (for consistency) also translate head3 and head4 to `\subsubpsection` and `\paragraph`