### PR TITLE
Incorrect end of comment detected

### DIFF
--- a/lib/Doxygen/Filter/Perl/POD.pm
+++ b/lib/Doxygen/Filter/Perl/POD.pm
@@ -185,7 +185,7 @@ sub view_item {
             my $anchor = $title;
             $anchor =~ s/^\s*|\s*$//g; # strip leading and closing spaces
             $anchor =~ s/\W/_/g;
-            $title =~ s/\*\//\\*&zwj;\//g;
+            $title =~ s/\*\//*&zwj;\//g;
             $title = qq{<a name="item_$anchor"></a><b>$title</b>};
         }
     }

--- a/lib/Doxygen/Filter/Perl/POD.pm
+++ b/lib/Doxygen/Filter/Perl/POD.pm
@@ -185,7 +185,7 @@ sub view_item {
             my $anchor = $title;
             $anchor =~ s/^\s*|\s*$//g; # strip leading and closing spaces
             $anchor =~ s/\W/_/g;
-            $title =~ s/\*\//\\*\\\//g;
+            $title =~ s/\*\//\\*&zwj;\//g;
             $title = qq{<a name="item_$anchor"></a><b>$title</b>};
         }
     }


### PR DESCRIPTION
In case, in an item we have something like: `=item 1. Add*/Mod*/Del*/ - high-level` then the `*/` are after translation to cpp seen as end of comment. So they have to be escaped.
(this might happen on other places as well, as soon as found they can be fixed in a similar way).

Note: end of comments in code section will be handled by doxygen in https://github.com/doxygen/doxygen/pull/7026