### PR TITLE
Incorrect end of comment detected

### DIFF
--- a/lib/Doxygen/Filter/Perl.pm
+++ b/lib/Doxygen/Filter/Perl.pm
@@ -808,6 +808,9 @@ sub _ProcessPodCommentBlock
     Doxygen::Filter::Perl::POD->setAsLabel($self->{'_hData'}->{'filename'}->{'fullpath'});
     my $sPodParsedText = Doxygen::Filter::Perl::POD->print($pom);
 
+    $sPodParsedText =~ s/\*\/\*/\\*\&zwj;\/\\*/g;
+    $sPodParsedText =~ s/\/\*/\/\&zwj;\\*/g;
+    $sPodParsedText =~ s/\*\//\\*\&zwj;\//g;
     $self->{'_hData'}->{'class'}->{$sClassName}->{'comments'} .= $sPodParsedText;
 }
 


### PR DESCRIPTION
 - In case, in an item we have something like: `=item 1. Add*/Mod*/Del*/ - high-level` then the `*/` are after translation to cpp seen as end of comment.
 - Same accounts for something like (in normal running text) `RPerl/Test/*/*Bad*.pm`

 So they have to be escaped.
As written with the proposed pull request https://github.com/jordan2175/doxygen-filter-perl/pull/11 which was just for the first mentioned case "this might happen on other places as well, as soon as found they can be fixed in a similar way", the second case has been found as well.
This proposed pull request supersedes the now withdrawn proposed pull request: https://github.com/jordan2175/doxygen-filter-perl/pull/11

Note: end of comments in code section will be handled by doxygen in https://github.com/doxygen/doxygen/pull/7026