### PR TITLE
Doxygen supports `<code>`

### DIFF
--- a/lib/Doxygen/Filter/Perl/POD.pm
+++ b/lib/Doxygen/Filter/Perl/POD.pm
@@ -118,6 +118,26 @@ sub view_head4
 }
 
 
+sub view_seq_code
+{
+    my ($self, $text) = @_;
+    $text =~ s/"/\\"/g;
+    return "<code>$text</code>";
+}
+
+
+sub view_verbatim {
+    my ($self, $text) = @_;
+    for ($text) {
+        s/&/&amp;/g;
+        s/</&lt;/g;
+        s/>/&gt;/g;
+        s/-/\\-/g;
+    }
+    return "<pre>$text</pre>\n\n";
+}
+
+
 =head1 NAME
 
 Doxygen::Filter::Perl::POD - A perl code pre-filter for Doxygen

--- a/lib/Doxygen/Filter/Perl/POD.pm
+++ b/lib/Doxygen/Filter/Perl/POD.pm
@@ -117,14 +117,6 @@ sub view_head4
     return "\n\@paragraph $sectionLabel$name$labelCnt $title\n" . $head4->content->present($self);
 }
 
-sub view_seq_code 
-{
-    my ($self, $text) = @_;
-    return "\n\@code\n$text\n\@endcode\n";
-}
-
-
-
 
 =head1 NAME
 


### PR DESCRIPTION
There is no need to replace the `<code>` with `\code` as doxygen supports the `<code>`.
In case of e.g.
```
C<Net::FTP::AutoReconnect> is a wrapper module around C<Net::FTP>.
```
this resulted in a number of lines as the `<code>` started a new block and we also got the warning:
```
warning: End of list marker found without any preceding list items
```
due to the `.` as single item starting a line.