### PR TITLE
Small prototype support

### DIFF
--- a/lib/Doxygen/Filter/Perl.pm
+++ b/lib/Doxygen/Filter/Perl.pm
@@ -712,7 +712,7 @@ sub _ProcessPerlMethod
         $sName =~ s/\s//g;
         # check if we have a prototype
         my ($method, $proto)  = split /[()]/, $sName;
-        $sName = $method;
+        $sName = $method || "";
         $sName =~ s/\s//g;
         if (defined($proto)) {$proto =~ s/\s//g;}
         my $sProtoType = $proto || "";


### PR DESCRIPTION
In the perl conversion script there is no support for perl prototypes like
```
sub otherwise (&;$) {
```
this leads to strange C code like:
```
@fn public method otherwise(&;$)()
```

This leads to problems with the generation and messages like:
```
warning: member with no name found.
```

This proposed patch adds
- detection of prototypes
- use just the prototype definition in case the parameter statement is not used (backward compatibility)
- translating `&` to 'subroutine' (was missing in the list)