### PR TITLE
Don't encode text

### DIFF
--- a/lib/Doxygen/Filter/Perl.pm
+++ b/lib/Doxygen/Filter/Perl.pm
@@ -381,6 +381,8 @@ sub PrintAll
     my $logger = $self->GetLogger($self);
     $logger->debug("### Entering PrintAll ###");
 
+    binmode STDOUT, ":utf8";
+
     $self->_PrintFilenameBlock();
     $self->_PrintIncludesBlock();
     

--- a/lib/Doxygen/Filter/Perl/POD.pm
+++ b/lib/Doxygen/Filter/Perl/POD.pm
@@ -123,6 +123,12 @@ sub view_seq_code
     return "\n\@code\n$text\n\@endcode\n";
 }
 
+sub encode {
+    my($self,$text) = @_;
+    return $text;
+}
+
+
 
 
 


### PR DESCRIPTION
This program is a filter but it, as it is the default, changes also t…he way some characters are represented e.g. when having a German o with umlaut this is encoded (Latin1) as octal ' 303' '266' and the filter changes this into `&#x76`, the filter should leave it as is and give it to doxygen that can decide by means of the `INPUT_ENCODING` how to handle the character.

This does also mean that we have to set STDOUT in binary mode so a sentence with e.g. Japanese characters cannot give the message:
```
Wide character in print at /usr/lib/perl5/site_perl/5.26.1/Doxygen/Filter/Perl.pm line 583
```