### PR TITLE
Recognizing subroutine definitions.

### DIFF
--- a/lib/Doxygen/Filter/Perl.pm
+++ b/lib/Doxygen/Filter/Perl.pm
@@ -213,7 +213,7 @@ sub ProcessFile
         if ($self->{'_sState'} eq 'NORMAL')
         {
             $logger->debug("We are in state: NORMAL");
-            if    ($line =~ /^\s*sub\s*(.*)/) { $self->_ChangeState('METHOD');  }
+            if    ($line =~ /^\s*sub\s+([a-zA-Z_].*)/) { $self->_ChangeState('METHOD');  }
             elsif ($line =~ /^\s*#\*\*\s*\@/) { $self->_ChangeState('DOXYGEN'); }
             elsif ($line =~ /^=.*/)           { $self->_ChangeState('POD');     }
         }
@@ -240,7 +240,7 @@ sub ProcessFile
                 {
                     # If this comment block is right next to a subroutine, lets make sure we
                     # handle that condition
-                    if ($line =~ /^\s*sub\s*(.*)/) { $self->_ChangeState('METHOD');  }
+                    if ($line =~ /^\s*sub\s+([a-zA-Z_].*)/) { $self->_ChangeState('METHOD');  }
                 }
             }
         }
@@ -672,7 +672,7 @@ sub _ProcessPerlMethod
     
     my $sClassName = $self->{'_sCurrentClass'};
 
-    if ($line =~ /^\s*sub\s+(.*)/) 
+    if ($line =~ /^\s*sub\s+([a-zA-Z_].*)/)
     {
         # We should keep track of the order in which the methods were written in the code so we can print 
         # them out in the same order

--- a/lib/Doxygen/Filter/Perl.pm
+++ b/lib/Doxygen/Filter/Perl.pm
@@ -213,7 +213,7 @@ sub ProcessFile
         if ($self->{'_sState'} eq 'NORMAL')
         {
             $logger->debug("We are in state: NORMAL");
-            if    ($line =~ /^\s*sub\s+([a-zA-Z_].*)/) { $self->_ChangeState('METHOD');  }
+            if    ($line =~ /^\s*sub\s+([\w]+)/ and $line =~ /^\s*sub\s+([\D][\w]*)/) { $self->_ChangeState('METHOD');  }
             elsif ($line =~ /^\s*#\*\*\s*\@/) { $self->_ChangeState('DOXYGEN'); }
             elsif ($line =~ /^=.*/)           { $self->_ChangeState('POD');     }
         }
@@ -240,7 +240,7 @@ sub ProcessFile
                 {
                     # If this comment block is right next to a subroutine, lets make sure we
                     # handle that condition
-                    if ($line =~ /^\s*sub\s+([a-zA-Z_].*)/) { $self->_ChangeState('METHOD');  }
+                    if ($line =~ /^\s*sub\s+([\w]+)/ and $line =~ /^\s*sub\s+([\D][\w]*)/) { $self->_ChangeState('METHOD');  }
                 }
             }
         }
@@ -672,7 +672,7 @@ sub _ProcessPerlMethod
     
     my $sClassName = $self->{'_sCurrentClass'};
 
-    if ($line =~ /^\s*sub\s+([a-zA-Z_].*)/)
+    if ($line =~ /^\s*sub\s+([\w]+)/ and $line =~ /^\s*sub\s+([\D][\w]*)/)
     {
         # We should keep track of the order in which the methods were written in the code so we can print 
         # them out in the same order


### PR DESCRIPTION
To prevent the recognition of e.g. `sub` in:
```
my %SenderArgs = (
  sendmail  => [],
  smtp      => [],
  sub       => [],
);
```
as start of a subroutine (and giving in doxygen the warning:
```
warning: member with no name found.
```
the recognition of subroutines has been adjusted.

Better recognition also in case of unicode. `\w` is all alphanumeric character plus `_`, but as the first character of a name cannot be a number we have to perform a small trick(`\D`, not numeric but it is unknown what is actually included so it is to be used together with the `\w` in the previous part giving the first character just the "alpha" characters puls the `_`)