### PR TITLE
Detection of package name

### DIFF
--- a/lib/Doxygen/Filter/Perl.pm
+++ b/lib/Doxygen/Filter/Perl.pm
@@ -258,7 +258,7 @@ sub ProcessFile
         # Process states
         if ($self->{'_sState'} eq 'NORMAL')
         {
-            if ($line =~ /^\s*package\s*(.*)\;$/) 
+            if ($line =~ /^\s*package\s*([^;]*)\;/)
             { 
                 #$self->{'_sCurrentClass'} = $1;
                 #push (@{$self->{'_hData'}->{'class'}->{'classorder'}}, $1);


### PR DESCRIPTION
The detection of a package name gives wrong results in case we have:
```
package Mail::SpamAssassin::Bayes::CombineChi; 1;
```
This gives a warning:
```
warning: the name '1' supplied as the argument of the \class, \struct, \union, or \include command is not an input file
```

we will now stop searching after the first ';'