### PR TITLE
issue #21 Version string in new release 1.73 not updated

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,7 +1,24 @@
 Release Notes:
+v1.73 - 2019-11-15
+    Changes
+        Detection of package name (see (see https://github.com/jordan2175/doxygen-filter-perl/pull/20)
+        Asterisk in prototype (see: https://github.com/jordan2175/doxygen-filter-perl/pull/19)
+        Recognizing subroutine definitions. (see https://github.com/jordan2175/doxygen-filter-perl/pull/18)
+        Don't encode text (see https://github.com/jordan2175/doxygen-filter-perl/pull/17)
+        Remove `\n` from headers (see https://github.com/jordan2175/doxygen-filter-perl/pull/15)
+        Small prototype support (see https://github.com/jordan2175/doxygen-filter-perl/pull/14)
+        Doxygen supports `<code>` (see https://github.com/jordan2175/doxygen-filter-perl/pull/13)
+        Incorrect end of comment detected (see https://github.com/jordan2175/doxygen-filter-perl/pull/12)
+        Make code section XHTML compatible (see https://github.com/jordan2175/doxygen-filter-perl/pull/10)
+        Correcting multiple use of doxygen section labels (see https://github.com/jordan2175/doxygen-filter-perl/pull/9)
+        Uninitialized variable (see https://github.com/jordan2175/doxygen-filter-perl/pull/8)
+        Fix for some uninitialized variables (see https://github.com/jordan2175/doxygen-filter-perl/pull/7)
+        Correct file name in case of space in the name (see https://github.com/jordan2175/doxygen-filter-perl/pull/6)
+        Uninitialized value $sOptions (see https://github.com/jordan2175/doxygen-filter-perl/pull/5)
+        issue #3 "Use of uninitialized value $sMethodName" problem (see https://github.com/jordan2175/doxygen-filter-perl/pull/4)
 v1.72 - 2015-03-23
     Changes
-        Un-did change from 1.71 and fixed it correctly by changing the Doxyfile
+        Fixed license (just in case)
 v1.71 - 2015-03-16
     Chnaged
         Fix issue where public objects were not showing up, if a private objects was found 

--- a/lib/Doxygen/Filter.pm
+++ b/lib/Doxygen/Filter.pm
@@ -18,7 +18,6 @@
 # @endverbatim
 #
 # @copy 2011, Bret Jordan (jordan2175@gmail.com, jordan@open1x.org)
-# $Id: Filter.pm 88 2012-07-07 04:27:35Z jordan2175 $
 #*
 package Doxygen::Filter;
 
@@ -27,7 +26,7 @@ use strict;
 use warnings;
 use Log::Log4perl;
 
-our $VERSION     = '1.72';
+our $VERSION     = '1.73';
 $VERSION = eval $VERSION;
 
 

--- a/lib/Doxygen/Filter/Perl.pm
+++ b/lib/Doxygen/Filter/Perl.pm
@@ -18,7 +18,6 @@
 # @endverbatim
 #
 # @copy 2011, Bret Jordan (jordan2175@gmail.com, jordan@open1x.org)
-# $Id: Perl.pm 93 2015-03-17 13:08:02Z jordan2175 $
 #*
 package Doxygen::Filter::Perl;
 
@@ -31,7 +30,7 @@ use Pod::POM;
 use IO::Handle;
 use Doxygen::Filter::Perl::POD;
 
-our $VERSION     = '1.72';
+our $VERSION     = '1.73';
 $VERSION = eval $VERSION;
 
 

--- a/lib/Doxygen/Filter/Perl/POD.pm
+++ b/lib/Doxygen/Filter/Perl/POD.pm
@@ -18,7 +18,6 @@
 # @endverbatim
 #
 # @copy 2011, Bret Jordan (jordan2175@gmail.com, jordan@open1x.org)
-# $Id: POD.pm 88 2012-07-07 04:27:35Z jordan2175 $
 #*
 package Doxygen::Filter::Perl::POD;
 
@@ -28,7 +27,7 @@ use warnings;
 use parent qw(Pod::POM::View::HTML);
 use Log::Log4perl;
 
-our $VERSION     = '1.72';
+our $VERSION     = '1.73';
 $VERSION = eval $VERSION;
 our $labelCnt = 0;  # label counter to see to it that when e.g. twice a =head1 NAME in a file it is still an unique label
 our $sectionLabel = 'x';


### PR DESCRIPTION
- Updated version string to 1.73
- removed ID as this is an old CVS type ID and not updated by git
- updated change log