### PR TITLE
Handling of comment and POD

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
     Test::More (1.001014)           [License = Perl]
     Test::Output (1.03)             [License = Perl]
     IO::Handle (1.34)
+    File::Slurp
     PPR
 
 ## LICENCE INFORMATION ##

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
     Test::More (1.001014)           [License = Perl]
     Test::Output (1.03)             [License = Perl]
     IO::Handle (1.34)
+    PPR
 
 ## LICENCE INFORMATION ##
 


### PR DESCRIPTION
When having a line like:
```
return $function && $function !~ /^[\s{#]/;
```
the part `#}/;` is incorrectly seen as comment, leading to an extra open brace and wrong counting of braces / determination where a method ends.

In principle the `PPR:decomment()` method (extra requirement for PPR package) can handle comments and POD, but has as disadvantage that POD parts are reduced to one line. By means of the new method `PPR:decomment2()` this problem is solved (Thanks to Hakon Hagland see also: https://stackoverflow.com/questions/61307663/retain-newlines-for-pod-in-case-of-ppruncomment/61309570#61309570).

In the part where we handle the methods we use the code without comments and POD to determine the structure, but we keep track of the original lines (raw lines) as the later are required in the code sections for doxygen.

Some further pointers from stackoverflow in respect to help for the different issues to overcome here: https://stackoverflow.com/questions/61289457/strip-all-comment-from-perl-file-using-perl-ppr, https://stackoverflow.com/questions/61274432/remove-comment-from-perl-file-using-perl and https://stackoverflow.com/questions/22665518/how-can-i-strip-all-comments-from-a-perl-script-except-for-the-shebang-line/61275208#61275208