### PR TITLE
Small incompatibility between PPR version 26 and Perl.pm

### DIFF
--- a/lib/Doxygen/Filter/Perl.pm
+++ b/lib/Doxygen/Filter/Perl.pm
@@ -172,8 +172,19 @@ sub ReadFile
     my @aRawFileData= split /(?<=\n)/, $aFileData;
     $self->{'_aRawFileData'} = \@aRawFileData;
     $self->{'_decommentOK'} = 1;
+    my $ppr_version;
+    $ppr_version = eval $PPR::VERSION;
     eval {
-      my $aUncommentFileData_tmp = PPR::decomment2(join($", $aFileData));
+      my $aUncommentFileData_tmp;
+      # comparing floating point numbers is a bit nasty, this will do here
+      if ($ppr_version < 0.0000259)
+      {
+        $aUncommentFileData_tmp = PPR::decomment2(join($", $aFileData));
+      }
+      else
+      {
+        $aUncommentFileData_tmp = PPR::decomment(join($", $aFileData));
+      }
       if (defined($PPR::ERROR))
       {
         $self->{'_decommentOK'} = 0;


### PR DESCRIPTION
The issues as reported against PPR where handled and placed into a release very fast. There were some in incompatibilities so it is better to call the official `PPR::decomment` for versions >= 26 and our version for versions <= 25.

See also:
- https://rt.cpan.org/Public/Bug/Display.html?id=132397
- https://rt.cpan.org/Public/Bug/Display.html?id=132411
- https://rt.cpan.org/Public/Bug/Display.html?id=132405