### PR TITLE
Warning about incorrect class name

### DIFF
--- a/lib/Doxygen/Filter/Perl.pm
+++ b/lib/Doxygen/Filter/Perl.pm
@@ -636,6 +636,7 @@ sub _PrintClassBlock
       $usedClass =~ s/\.p[lm]$//;
       $usedClass =~ s/-/_/g;
       $usedClass =~ s/\./_/g;
+      $usedClass =~ s/\+/_/g;
       $usedClass =~ s/^/main_/;
     }
     print "/** \@class $usedClass\n";

--- a/lib/Doxygen/Filter/Perl.pm
+++ b/lib/Doxygen/Filter/Perl.pm
@@ -635,6 +635,7 @@ sub _PrintClassBlock
       $usedClass = $self->{'_hData'}->{'filename'}->{'shortname'};
       $usedClass =~ s/\.p[lm]$//;
       $usedClass =~ s/-/_/g;
+      $usedClass =~ s/\./_/g;
       $usedClass =~ s/^/main_/;
     }
     print "/** \@class $usedClass\n";


### PR DESCRIPTION
In pull request #25  problem of  'All "main" files are squashed into one class' was solved though when a filename has multiple dots like in `convert0.6.pl` we get:
```
warning: the name '6' supplied as the argument of the \class, \struct, \union, or \include command is not an input file
```
we have to escape the dot as well like already done for the minus sign.