### PR TITLE
Windows drive letter incorrectly detected

### DIFF
--- a/lib/Doxygen/Filter/Perl.pm
+++ b/lib/Doxygen/Filter/Perl.pm
@@ -161,7 +161,7 @@ sub ReadFile
     # Replace forward slash with a black slash
     $sFilename =~ s/\\/\//g;
     # Remove windows style drive letters
-    $sFilename =~ s/^.*://;
+    $sFilename =~ s/^.://;
  
     # Lets grab just the file name not the full path for the short name
     $sFilename =~ /^(.*\/)*(.*)$/;


### PR DESCRIPTION
A windows drive letter can only be one character now the filename from e.g. ../package::file.pl was incorrectly  detected as file.pl instead of package::file.pl (it is a bit of a strange file name)