### PR TITLE
Recursive inheritance of classes

### DIFF
--- a/lib/Doxygen/Filter/Perl.pm
+++ b/lib/Doxygen/Filter/Perl.pm
@@ -667,7 +667,10 @@ sub _PrintClassBlock
         {
             if (defined($inherit))
             {
-                print(($count++ == 0 ? ": " : ", ")." public ::".$inherit);
+                if ($sFullClass ne $inherit)
+                {
+                    print(($count++ == 0 ? ": " : ", ")." public ::".$inherit);
+                }
             }
 
         }


### PR DESCRIPTION
When there is something like:
```
package PDL::Transform;

our @EXPORT_OK = qw(apply invert map map unmap t_inverse t_compose t_wrap t_identity t_lookup t_linear t_scale t_offset  t_rot t_fits t_code  t_cylindrical t_radial t_quadratic t_cubic t_quadratic t_spherical t_projective );
our %EXPORT_TAGS = (Func=>\@EXPORT_OK);

use PDL::Core;
use PDL::Exporter;
use DynaLoader;

   our @ISA = ( 'PDL::Exporter','DynaLoader' );
   push @PDL::Core::PP, __PACKAGE__;
   bootstrap PDL::Transform ;

```
in the code and later on:
```
....
{ package PDL::Transform::Linear;
our @ISA = ('PDL::Transform');
*_opt = \&PDL::Transform::_opt;
...
```
this results in the line:
```
namespace PDL {
class Transform:  public ::PDL::Exporter,  public ::DynaLoader,  public ::PDL::Transform
{

```
i.e. recursive inheritance, which has now been excluded by means of the `if` clause.

Note: the meaning of the `{`  here is not clean whether this is some sort of innerclass (in Cpp terms) and might have to be handled differently. The pach just removes the problem.


The source code of the file where the problem occurred and its translation by the filter: [transform.tar.gz](https://github.com/jordan2175/doxygen-filter-perl/files/9893549/transform.tar.gz)
Original repository: https://github.com/PDLPorters/pdl
Found by Fossies

